### PR TITLE
Override the OAuth2Strategy authorizationParams() method

### DIFF
--- a/lib/passport-forcedotcom/strategy.js
+++ b/lib/passport-forcedotcom/strategy.js
@@ -90,6 +90,13 @@ Strategy.prototype.userProfile = function(accessToken, cb) {
 };
 
 /**
+ * Override the OAuth2Strategy authorizationParams() method.
+ */
+Strategy.prototype.authorizationParams = function(options) {
+  return (options && (typeof options === 'object')) ? options : {};
+};
+
+  /**
  * Wrapper for getting JSON with the specified access token.
  */
 Strategy.prototype.getJSON = function(theUrl, token, cb) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "passport-forcedotcom",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Salesforce.com/Force.com/Database.com authentication strategy for Passport.",
   "author": {
     "name": "Joshua Birk",


### PR DESCRIPTION
Override the OAuth2Strategy authorizationParams() method to allow for passing of authorization options (prompt, display, login_hint, ...)