### PR TITLE
passport-oauth2@1.3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "license": "BSD-3-Clause",
   "main": "./lib/passport-forcedotcom",
   "dependencies": {
-    "passport-oauth2": "1.1.2"
+    "passport-oauth2": "1.3.x"
   },
   "engines": {
     "node": ">= 0.4.0"


### PR DESCRIPTION
update to the latest version of `passport-oauth2` (there are no breaking changes)