### PR TITLE
Support state parameter

### DIFF
--- a/lib/passport-forcedotcom/strategy.js
+++ b/lib/passport-forcedotcom/strategy.js
@@ -63,6 +63,9 @@ Strategy.prototype.authorizationParams = function(options) {
     
   if (options.login_hint)
     params.login_hint = options.login_hint;
+  
+  if (options.state)
+    params.state = options.state;
 
   return params;
 };


### PR DESCRIPTION
Add support for the `state` parameter as defined in https://help.salesforce.com/articleView?id=remoteaccess_oauth_web_server_flow.htm&type=0

This parameter allows arbitrary URL encoded data to be passed back and forth between the Passport app and SalesForce.