### PR TITLE
Still return the profile if the url on the rawProfile.urls.users is undefined

### DIFF
--- a/lib/passport-forcedotcom/strategy.js
+++ b/lib/passport-forcedotcom/strategy.js
@@ -93,7 +93,7 @@ Strategy.prototype.userProfile = function(accessToken, cb) {
       _raw: rawProfile,
     };
 
-    if (self._skipPhoto) {
+    if (self._skipPhoto || !rawProfile.urls.users) {
       return cb(null, self.coerceProfile(profile));
     }
 


### PR DESCRIPTION
`rawProfile.url.users` seems be undefined in some rare cases. I haven't been able to figure when or why this is the case but it causes a fatal error. 

this fixes a TypeError by simply doing the same as the skip photo option and returning the profile without a `_photo` param if this url is undefined. this is so that we don't end up with the type error mentioned in the linked issue when passing undefined to `url.parse` 

https://github.com/joshbirk/passport-forcedotcom/issues/28