### PR TITLE
[ULP-5480] use auth0 fork passport-oauth2 v1.7.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "passport-forcedotcom",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "passport-forcedotcom",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "passport-oauth2": "^1.6.1"
+        "passport-oauth2": "auth0/passport-oauth2#v1.7.1"
       },
       "devDependencies": {
         "chai": "~1.9.0",
@@ -1382,9 +1382,9 @@
       }
     },
     "node_modules/passport-oauth2": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/passport-oauth2/-/passport-oauth2-1.6.1.tgz",
-      "integrity": "sha512-ZbV43Hq9d/SBSYQ22GOiglFsjsD1YY/qdiptA+8ej+9C1dL1TVB+mBE5kDH/D4AJo50+2i8f4bx0vg4/yDDZCQ==",
+      "version": "1.7.0",
+      "resolved": "git+ssh://git@github.com/auth0/passport-oauth2.git#a029de09229b2da1fc68801e47fc6e29df1f3b6c",
+      "license": "MIT",
       "dependencies": {
         "base64url": "3.x.x",
         "oauth": "0.9.x",
@@ -2912,9 +2912,8 @@
       }
     },
     "passport-oauth2": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/passport-oauth2/-/passport-oauth2-1.6.1.tgz",
-      "integrity": "sha512-ZbV43Hq9d/SBSYQ22GOiglFsjsD1YY/qdiptA+8ej+9C1dL1TVB+mBE5kDH/D4AJo50+2i8f4bx0vg4/yDDZCQ==",
+      "version": "git+ssh://git@github.com/auth0/passport-oauth2.git#a029de09229b2da1fc68801e47fc6e29df1f3b6c",
+      "from": "passport-oauth2@auth0/passport-oauth2#v1.7.1",
       "requires": {
         "base64url": "3.x.x",
         "oauth": "0.9.x",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "license": "BSD-3-Clause",
   "main": "./lib/passport-forcedotcom",
   "dependencies": {
-    "passport-oauth2": "^1.6.1"
+    "passport-oauth2": "auth0/passport-oauth2#v1.7.1"
   },
   "engines": {
     "node": ">= 0.4.0"


### PR DESCRIPTION
Uses forked version of passport-oauth2 tagged with v1.7.1 which contains all of v1.7.0 changes and remove the problematic access_token check